### PR TITLE
Output property eventhough indexer exists

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -693,7 +693,7 @@ namespace PublicApiGenerator
             var defaultMemberAttributeValue = typeDeclarationInfo.CustomAttributes.SingleOrDefault(x =>
                     x.AttributeType.FullName == "System.Reflection.DefaultMemberAttribute")
                 ?.ConstructorArguments.Select(x => x.Value).OfType<string>().SingleOrDefault();
-            if (!string.IsNullOrEmpty(defaultMemberAttributeValue) && member.Name != "Item")
+            if (!string.IsNullOrEmpty(defaultMemberAttributeValue) && member.Name == defaultMemberAttributeValue && member.Name != "Item")
             {
                 property.Name = "Item";
                 property.CustomAttributes.Add(

--- a/src/PublicApiGeneratorTests/Indexer_properties.cs
+++ b/src/PublicApiGeneratorTests/Indexer_properties.cs
@@ -49,6 +49,35 @@ namespace PublicApiGeneratorTests
     }
 }");
         }
+
+        [Fact]
+        public void Should_output_other_properties_when_indexer_exists()
+        {
+            AssertPublicApi<InterfaceWithIndexerAndAnotherProperty>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public interface InterfaceWithIndexerAndAnotherProperty
+    {
+        object this[string key] { get; }
+        string Property { get; }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_other_properties_when_named_indexer_exists()
+        {
+            AssertPublicApi<InterfaceWithNamedIndexerAndAnotherProperty>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public interface InterfaceWithNamedIndexerAndAnotherProperty
+    {
+        [System.Runtime.CompilerServices.IndexerName(""Bar"")]
+        object this[string key] { get; }
+        string Property { get; }
+    }
+}");
+        }
     }
 
 
@@ -78,6 +107,21 @@ namespace PublicApiGeneratorTests
                 get => y;
                 set => y = value;
             }
+        }
+
+        public interface InterfaceWithIndexerAndAnotherProperty
+        {
+            string Property { get; }
+
+            object this[string key] { get; }
+        }
+
+        public interface InterfaceWithNamedIndexerAndAnotherProperty
+        {
+            string Property { get; }
+
+            [IndexerName("Bar")]
+            object this[string key] { get; }
         }
     }
     // ReSharper restore ValueParameterNotUsed


### PR DESCRIPTION
regression in #136 

I was very surprised when I saw this :)
```c# public interface IMessageProperties
    {
        [System.Runtime.CompilerServices.IndexerName("Item")]
        string Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        string Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        string Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        string Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        System.DateTime? Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        System.DateTime? Item { get; }
        object this[string key] { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        string Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        string Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        int Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        string Item { get; }
        [System.Runtime.CompilerServices.IndexerName("Item")]
        System.TimeSpan? Item { get; }
        TValue GetProperty<TValue>(string key, TValue defaultValue = null);
    }
```