### PR TITLE
Fix Windows build script to CD to project directory

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,6 @@
 @echo Off
+setlocal
+cd "%~dp0"
 
 dotnet build ./src/PublicApiGenerator.sln --configuration Release /nologo  || goto :error
 dotnet test ./src/PublicApiGenerator.sln --configuration Release --no-build --verbosity=normal /nologo  || goto :error


### PR DESCRIPTION
This PR fixes issue #164 by changing the current working directory to that of the project at the start. The `setlocal` will ensure that the current working directory is restored when the batch terminates (successfully or unsuccessfully).