### PR TITLE
Consistently write errors & log to standard error

### DIFF
--- a/src/PublicApiGenerator.Tool/Program.cs
+++ b/src/PublicApiGenerator.Tool/Program.cs
@@ -79,7 +79,7 @@ namespace PublicApiGenerator.Tool
             }
         }
 
-        private static void GeneratePublicApi(string? assembly, string? package, string workingArea, string framework, string? outputDirectory, TextWriter log)
+        private static void GeneratePublicApi(string? assembly, string? package, string workingArea, string framework, string? outputDirectory, TextWriter? log)
         {
             var relativePath = Path.Combine(workingArea, "bin", "Release", framework);
             var name = !string.IsNullOrEmpty(assembly) ? $"{assembly}" : $"{package}.dll";
@@ -102,7 +102,7 @@ namespace PublicApiGenerator.Tool
             }
         }
 
-        private static void RunDotnet(string workingArea, TextWriter log, string arguments)
+        private static void RunDotnet(string workingArea, TextWriter? log, string arguments)
         {
             log?.WriteLine($"Dotnet arguments: {arguments}");
             log?.WriteLine();
@@ -131,7 +131,7 @@ namespace PublicApiGenerator.Tool
             }
         }
 
-        private static void SaveProjectTemplate(string workingArea, string template, TextWriter log)
+        private static void SaveProjectTemplate(string workingArea, string template, TextWriter? log)
         {
             Directory.CreateDirectory(workingArea);
             var fullPath = Path.Combine(workingArea, "project.csproj");

--- a/src/PublicApiGenerator.Tool/Program.cs
+++ b/src/PublicApiGenerator.Tool/Program.cs
@@ -11,6 +11,8 @@ namespace PublicApiGenerator.Tool
     /// </summary>
     public static class Program
     {
+        static TextWriter? _log;
+
         /// <summary>
         /// Public API generator tool that is useful for semantic versioning
         /// </summary>
@@ -43,8 +45,10 @@ namespace PublicApiGenerator.Tool
 
             if (verbose)
             {
-                Console.WriteLine($"Working area: {workingArea}");
+                _log = Console.Error;
             }
+
+            _log?.WriteLine($"Working area: {workingArea}");
 
             try
             {
@@ -93,11 +97,8 @@ namespace PublicApiGenerator.Tool
                 // Because we run in different appdomain we can always unload
                 RunDotnet(workingArea, verbose, $"run --configuration Release --framework {framework} -- {fullPath} {outputPath} {outputDirectory}");
 
-                if (verbose)
-                {
-                    Console.WriteLine($"Public API file: {outputPath}");
-                    Console.WriteLine();
-                }
+                _log?.WriteLine($"Public API file: {outputPath}");
+                _log?.WriteLine();
             }
             catch (FileNotFoundException)
             {
@@ -108,11 +109,8 @@ namespace PublicApiGenerator.Tool
 
         private static void RunDotnet(string workingArea, bool verbose, string arguments)
         {
-            if (verbose)
-            {
-                Console.WriteLine($"Dotnet arguments: {arguments}");
-                Console.WriteLine();
-            }
+            _log?.WriteLine($"Dotnet arguments: {arguments}");
+            _log?.WriteLine();
 
             var psi = new ProcessStartInfo
             {
@@ -127,11 +125,8 @@ namespace PublicApiGenerator.Tool
 
             var output = process.StandardOutput.ReadToEnd();
 
-            if (verbose)
-            {
-                Console.WriteLine($"Dotnet output: {output}");
-                Console.WriteLine();
-            }
+            _log?.WriteLine($"Dotnet output: {output}");
+            _log?.WriteLine();
 
             if (process.ExitCode != 0)
             {
@@ -147,12 +142,9 @@ namespace PublicApiGenerator.Tool
             var fullPath = Path.Combine(workingArea, "project.csproj");
             using (var output = File.CreateText(fullPath))
             {
-                if (verbose)
-                {
-                    Console.WriteLine($"Project output path: {fullPath}");
-                    Console.WriteLine($"Project template: {template}");
-                    Console.WriteLine();
-                }
+                _log?.WriteLine($"Project output path: {fullPath}");
+                _log?.WriteLine($"Project template: {template}");
+                _log?.WriteLine();
 
                 output.Write(template);
             }
@@ -160,12 +152,9 @@ namespace PublicApiGenerator.Tool
             fullPath = Path.Combine(workingArea, "Program.cs");
             using (var output = File.CreateText(fullPath))
             {
-                if (verbose)
-                {
-                    Console.WriteLine($"Program output path: {fullPath}");
-                    Console.WriteLine($"Program template: {ProgramMain}");
-                    Console.WriteLine();
-                }
+                _log?.WriteLine($"Program output path: {fullPath}");
+                _log?.WriteLine($"Program template: {ProgramMain}");
+                _log?.WriteLine();
 
                 output.Write(ProgramMain);
             }


### PR DESCRIPTION
_Some_ errors would be sent to `STDOUT` as well as _all_ logging.

This PR consistently sends logging and errors to `STDERR` as opposed to having a mixed case of the two.