### PR TITLE
Use exact package version

### DIFF
--- a/src/PublicApiGenerator.Tool/Program.cs
+++ b/src/PublicApiGenerator.Tool/Program.cs
@@ -228,7 +228,7 @@ namespace PublicApiGenerator.Tool
 
         private static readonly string PackageReferenceTemplate =
             @"
-        <PackageReference Include=""{PackageName}"" Version=""{PackageVersion}"" />";
+        <PackageReference Include=""{PackageName}"" Version=""[{PackageVersion}]"" />";
 
         private static readonly string ProjectReferenceTemplate =
             @"<ItemGroup>


### PR DESCRIPTION
This PR implements [the suggestion](https://github.com/PublicApiGenerator/PublicApiGenerator/pull/169#issuecomment-579445359) from @bording in a [comment](https://github.com/PublicApiGenerator/PublicApiGenerator/pull/169#issuecomment-579445359) on PR #169. It either uses the exact version specified via the `--package-version` switch or fails. Like PR #169, this PR still constitutes a breaking behavioural change but I find it more of a bug fix (up to @danielmarbach to reconsider). Anyone relying on the current behaviour could be mislead (the chance that the public API generated is from another version than the one specified), as I was and which prompted the reporting of issue #168.