### PR TITLE
Fix tool help to show descriptions of arguments

### DIFF
--- a/src/PublicApiGenerator.Tool/Program.cs
+++ b/src/PublicApiGenerator.Tool/Program.cs
@@ -11,6 +11,9 @@ namespace PublicApiGenerator.Tool
     /// </summary>
     public static class Program
     {
+        /// <summary>
+        /// Public API generator tool that is useful for semantic versioning
+        /// </summary>
         /// <param name="targetFrameworks">Target frameworks to use to restore packages in. Must be a suitable target framework for executables like netcoreapp2.1. It is possible to specify multiple target frameworks like netcoreapp2.1;net461</param>
         /// <param name="assembly">The assembly name including the extension (i.ex. PublicApiGenerator.dll) to generate a public API from in case in differs from the package name.</param>
         /// <param name="projectPath">The path to the csproj that should be used to build the public API.</param>


### PR DESCRIPTION
Running the tool with `--help` before this PR:

```
Usage:
  PublicApiGenerator.Tool [options]

Options:
  --target-frameworks <TARGET-FRAMEWORKS>    targetFrameworks
  --assembly <ASSEMBLY>                      assembly
  --project-path <PROJECT-PATH>              projectPath
  --package <PACKAGE>                        package
  --package-version <PACKAGE-VERSION>        packageVersion
  --generator-version <GENERATOR-VERSION>    generatorVersion
  --working-directory <WORKING-DIRECTORY>    workingDirectory
  --output-directory <OUTPUT-DIRECTORY>      outputDirectory
  --verbose <VERBOSE>                        verbose
  --leave-artifacts <LEAVE-ARTIFACTS>        leaveArtifacts
  --version                                  Display version information
```

Note that descriptions of arguments is not being picked up from XML comments in code as per the [DragonFruit wiki](https://github.com/dotnet/command-line-api/wiki/DragonFruit-overview).

Running the tool with `--help` after this PR:

```
PublicApiGenerator.Tool:
  Public API generator tool that is useful for semantic versioning

Usage:
  PublicApiGenerator.Tool [options]

Options:
  --target-frameworks <TARGET-FRAMEWORKS>    Target frameworks to use to restore packages in. Must be a suitable target framework for executables like netcoreapp2.1. It is possible to specify multiple target frameworks like netcoreapp2.1;net461
  --assembly <ASSEMBLY>                      The assembly name including the extension (i.ex. PublicApiGenerator.dll) to generate a public API from in case in differs from the package name.
  --project-path <PROJECT-PATH>              The path to the csproj that should be used to build the public API.
  --package <PACKAGE>                        The package name from which a public API should be created. The tool assumes the package name equals the assembly name. If the assembly name is different specify
  --package-version <PACKAGE-VERSION>        The version of the package defined in to be used.
  --generator-version <GENERATOR-VERSION>    The version of the PublicApiGenerator package to use.
  --working-directory <WORKING-DIRECTORY>    The working directory to be used for temporary work artifacts. A temporary directory will be created inside the working directory and deleted once the process is done. If no working directory is specified the users temp directory is used.
  --output-directory <OUTPUT-DIRECTORY>      The output directory where the generated public APIs should be moved.
  --verbose <VERBOSE>                        
  --leave-artifacts <LEAVE-ARTIFACTS>        
  --version                                  Display version information
```

Oddly, just adding a `<summary>` for `Main` seems to fix this issue. This may be a bug in [System.CommandLine](https://github.com/dotnet/command-line-api)'s DragonFruit implementation.
