### PR TITLE
Embed sub-program source as a resource

### DIFF
--- a/src/PublicApiGenerator.Tool/PublicApiGenerator.Tool.csproj
+++ b/src/PublicApiGenerator.Tool/PublicApiGenerator.Tool.csproj
@@ -12,6 +12,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="SubProgram.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="SubProgram.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.2.0-alpha.19156.3" />
     <PackageReference Include="MinVer" Version="1.1.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/PublicApiGenerator.Tool/SubProgram.cs
+++ b/src/PublicApiGenerator.Tool/SubProgram.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Reflection;
+using System.IO;
+using PublicApiGenerator;
+
+static class Program
+{
+    static void Main(string[] args)
+    {
+        var fullPath = args[0];
+        var outputPath = args[1];
+        var outputDirectory = args[2];
+        var asm = Assembly.LoadFile(fullPath);
+        File.WriteAllText(outputPath, asm.GeneratePublicApi());
+        var destinationFilePath = Path.Combine(outputDirectory, Path.GetFileName(outputPath));
+        if (File.Exists(destinationFilePath))
+        {
+            File.Delete(destinationFilePath);
+        }
+        File.Move(outputPath, destinationFilePath);
+    }
+}


### PR DESCRIPTION
Borrowing from #177, I'd like to propose moving the generator sub-program source code into a separate file that's embedded as a resource as opposed to a string literal to help with maintenance, validation and easier reading (syntax highlighting).

Also note that I removed the unnecessary `public` modifiers from the sub-program's `Program` and `Main` (thus defaulting to `internal`). If you prefer to record that as a separate edit/commit then I can split it from this PR.
