### PR TITLE
Generate API on STDOUT when single target framework given

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ Generate public API for fluent assertions 5.* for runtime framework `net47`
 generate-public-api --target-frameworks net47 --package FluentAssertions --package-version 5.*
 ```
 
+Note that when a single target framework is specified then the API is generated to standard output. To write to a file, you can either use shell redirection:
+
+```
+generate-public-api --target-frameworks net47 --package FluentAssertions --package-version 5.* > api.txt
+```
+
+or specify an output directory to force the generation of an API file:
+
+```
+generate-public-api --target-frameworks net47 --package FluentAssertions --package-version 5.* --output-directory .
+```
+
 Generate public API for fluent assertions 5.6.0 (exact version match) for runtime framework `net47`
 
 ```
@@ -160,6 +172,8 @@ The target framework in which the package will be restored. The target framework
 - `net47` to build a public API for `net47`
 
 It is not possible to use `netstandard2.0` because it is not a valid runtime framework.
+
+If only a single target framework is given then the API is generated to the standard output unless the `--output-directory` option is also specified.
 
 ```
 --package-name PackageName

--- a/src/PublicApiGenerator.Tool/Program.cs
+++ b/src/PublicApiGenerator.Tool/Program.cs
@@ -113,7 +113,9 @@ namespace PublicApiGenerator.Tool
             }
 
             if (outputDirectory == null || apiFilePath == null)
+            {
                 return;
+            }
 
             logVerbose.WriteLine($"Public API file: {apiFilePath}");
             logVerbose.WriteLine();
@@ -146,7 +148,6 @@ namespace PublicApiGenerator.Tool
             logVerbose.WriteLine();
 
             using var process = Process.Start(psi);
-
 
             if (stdout == null)
             {
@@ -185,7 +186,10 @@ namespace PublicApiGenerator.Tool
                 (_, args) =>
                 {
                     if (args.Data == null)
+                    {
                         return; // EOI
+                    }
+
                     writer.WriteLine(prefix + args.Data);
                 };
         }
@@ -221,7 +225,10 @@ namespace PublicApiGenerator.Tool
         {
             using var stream = type.Assembly.GetManifestResourceStream(type, name);
             if (stream == null)
+            {
                 throw new Exception($"Resource named \"{type.Namespace}.{name}\" not found.");
+            }
+            
             using var reader = encoding == null ? new StreamReader(stream)
                                                 : new StreamReader(stream, encoding);
             return reader.ReadToEnd();

--- a/src/PublicApiGenerator.Tool/Program.cs
+++ b/src/PublicApiGenerator.Tool/Program.cs
@@ -147,15 +147,6 @@ namespace PublicApiGenerator.Tool
 
             using var process = Process.Start(psi);
 
-            static DataReceivedEventHandler
-                DataReceivedEventHandler(TextWriter writer,
-                                         string? prefix = null) =>
-                (_, args) =>
-                {
-                    if (args.Data == null)
-                        return; // EOI
-                    writer.WriteLine(prefix + args.Data);
-                };
 
             if (stdout == null)
             {
@@ -188,6 +179,15 @@ namespace PublicApiGenerator.Tool
                 throw new Exception(
                     $"dotnet exit code {process.ExitCode}. Directory: {workingArea}. Args: {pseudoCommandLine}.");
             }
+
+            static DataReceivedEventHandler
+                DataReceivedEventHandler(TextWriter writer, string? prefix = null) =>
+                (_, args) =>
+                {
+                    if (args.Data == null)
+                        return; // EOI
+                    writer.WriteLine(prefix + args.Data);
+                };
         }
 
         private static void SaveProject(string workingArea, XElement project, TextWriter logVerbose)

--- a/src/PublicApiGenerator.Tool/SubProgram.cs
+++ b/src/PublicApiGenerator.Tool/SubProgram.cs
@@ -5,18 +5,23 @@ using PublicApiGenerator;
 
 static class Program
 {
-    static void Main(string[] args)
+    static int Main(string[] args)
     {
-        var fullPath = args[0];
-        var outputPath = args[1];
-        var outputDirectory = args[2];
-        var asm = Assembly.LoadFile(fullPath);
-        File.WriteAllText(outputPath, asm.GeneratePublicApi());
-        var destinationFilePath = Path.Combine(outputDirectory, Path.GetFileName(outputPath));
-        if (File.Exists(destinationFilePath))
+        try
         {
-            File.Delete(destinationFilePath);
+            var assemblyPath = args[0];
+            var asm = Assembly.LoadFile(assemblyPath);
+            switch (args[1])
+            {
+                case "-": Console.WriteLine(asm.GeneratePublicApi()); break;
+                case string apiFilePath: File.WriteAllText(apiFilePath, asm.GeneratePublicApi()); break;
+            }
+            return 0;
         }
-        File.Move(outputPath, destinationFilePath);
+        catch (Exception e)
+        {
+            Console.Error.WriteLine(e);
+            return 1;
+        }
     }
 }


### PR DESCRIPTION
This PR addresses #173.
Replaces #180 

## Notable Changes

The _worker_ project's `Program.Main` takes two parameters only: the source assembly path and the output API file path. If the latter is `-` then the API is generated to standard output. It also logs unhandled exceptions to standard error and sets an exit code on success or failure. It is no longer the responsibility of the worker project to do any file operations like deleting and moving. This is done by PublicApiGenerator.

If `dotnet run` times out (after 10 seconds, which seems short to be honest) then an exception is thrown. Previously, PublicApiGenerator continue silently.
