### PR TITLE
Ensure that `SerializableAttribute` gets reproduced in output

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -441,6 +441,23 @@ namespace PublicApiGenerator
                 var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
                 attributes.Add(attribute);
             }
+
+            // so this is not very cool but at least all the attribute creation is in the same place
+            PopulateAttributesThatDontAppearInCustomAttributes(type, attributes);
+        }
+
+        static void PopulateAttributesThatDontAppearInCustomAttributes(ICustomAttributeProvider type,
+            CodeAttributeDeclarationCollection attributes)
+        {
+            if (type is TypeDefinition typeDefinition)
+            {
+                if (typeDefinition.Attributes.HasFlag(Mono.Cecil.TypeAttributes.Serializable))
+                {
+                    var attribute = new CodeAttributeDeclaration("System.SerializableAttribute");
+                    attribute.Name = AttributeNameBuilder.Get(attribute.Name);
+                    attributes.Add(attribute);
+                }
+            }
         }
 
         static CodeAttributeDeclaration GenerateCodeAttributeDeclaration(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
@@ -667,7 +684,7 @@ namespace PublicApiGenerator
                 // this seems right for default
                 return "default";
             }
-            
+
             return parameter.ParameterType.IsValueType ? "default" : "null";
         }
 

--- a/src/PublicApiGeneratorTests/Class_attributes.cs
+++ b/src/PublicApiGeneratorTests/Class_attributes.cs
@@ -301,7 +301,7 @@ namespace PublicApiGeneratorTests
             AssertPublicApi<ClassWithSerializableAttribute>(
                 @"namespace PublicApiGeneratorTests.Examples
 {
-    [System.SerializableAttribute]
+    [System.Serializable]
     public class ClassWithSerializableAttribute
     {
         public ClassWithSerializableAttribute() { }

--- a/src/PublicApiGeneratorTests/Class_attributes.cs
+++ b/src/PublicApiGeneratorTests/Class_attributes.cs
@@ -1,5 +1,5 @@
-﻿using PublicApiGenerator;
 using PublicApiGeneratorTests.Examples;
+using System;
 using Xunit;
 
 namespace PublicApiGeneratorTests
@@ -294,6 +294,20 @@ namespace PublicApiGeneratorTests
     }
 }", options);
         }
+
+        [Fact]
+        public void Should_include_Serializable_attribute()
+        {
+            AssertPublicApi<ClassWithSerializableAttribute>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    [System.SerializableAttribute]
+    public class ClassWithSerializableAttribute
+    {
+        public ClassWithSerializableAttribute() { }
+    }
+}");
+        }
     }
 
     // ReSharper disable UnusedMember.Global
@@ -401,6 +415,11 @@ namespace PublicApiGeneratorTests
 
         [AttributeWhichIsInternal]
         public class ClassWithInternalAttribute
+        {
+        }
+
+        [Serializable]
+        public class ClassWithSerializableAttribute
         {
         }
     }


### PR DESCRIPTION
Repro unit test and fix for #190.

~~Marking this as a draft, as I might add more commits later and convert this into a bugfix PR.~~

Fixes #190.