### PR TITLE
Fix syntax for overloaded operator methods

### DIFF
--- a/src/PublicApiGenerator/CSharpOperatorKeyword.cs
+++ b/src/PublicApiGenerator/CSharpOperatorKeyword.cs
@@ -6,6 +6,8 @@ namespace PublicApiGenerator
     {
         static readonly IDictionary<string, string> OperatorNameMap = new Dictionary<string, string>
         {
+            { "op_False", "false" },
+            { "op_True", "true" },
             { "op_Addition", "+" },
             { "op_UnaryPlus", "+" },
             { "op_Subtraction", "-" },
@@ -32,7 +34,7 @@ namespace PublicApiGenerator
 
         public static string Get(string memberName)
         {
-            return OperatorNameMap.TryGetValue(memberName, out string mappedMemberName) ? mappedMemberName : memberName;
+            return OperatorNameMap.TryGetValue(memberName, out string mappedMemberName) ? "operator " + mappedMemberName : memberName;
         }
     }
 }

--- a/src/PublicApiGeneratorTests/Operator_order.cs
+++ b/src/PublicApiGeneratorTests/Operator_order.cs
@@ -14,14 +14,14 @@ namespace PublicApiGeneratorTests
     public class ClassWithUnaryOperators
     {
         public ClassWithUnaryOperators() { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators !(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators +(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators ++(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators -(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators --(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static bool op_False(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static bool op_True(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators ~(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators operator !(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators operator +(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators operator ++(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators operator -(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators operator --(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static bool operator false(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static bool operator true(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithUnaryOperators operator ~(PublicApiGeneratorTests.Examples.ClassWithUnaryOperators first) { }
     }
 }");
         }
@@ -35,16 +35,16 @@ namespace PublicApiGeneratorTests
     public class ClassWithBinaryOperators
     {
         public ClassWithBinaryOperators() { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators %(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators &(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators *(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators +(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators -(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators /(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators <<(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, int second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators >>(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, int second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators ^(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
-        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators |(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator %(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator &(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator *(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator +(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator -(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator /(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator <<(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, int second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator >>(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, int second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator ^(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithBinaryOperators operator |(PublicApiGeneratorTests.Examples.ClassWithBinaryOperators first, PublicApiGeneratorTests.Examples.ClassWithBinaryOperators second) { }
     }
 }");
         }
@@ -58,12 +58,12 @@ namespace PublicApiGeneratorTests
     public class ClassWithComparisonOperators
     {
         public ClassWithComparisonOperators() { }
-        public static bool !=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
-        public static bool <(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
-        public static bool <=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
-        public static bool ==(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
-        public static bool >(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
-        public static bool >=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool operator !=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool operator <(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool operator <=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool operator ==(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool operator >(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
+        public static bool operator >=(PublicApiGeneratorTests.Examples.ClassWithComparisonOperators first, PublicApiGeneratorTests.Examples.ClassWithComparisonOperators second) { }
     }
 }");
         }

--- a/src/PublicApiGeneratorTests/Operator_visibility.cs
+++ b/src/PublicApiGeneratorTests/Operator_visibility.cs
@@ -14,7 +14,7 @@ namespace PublicApiGeneratorTests
     public class ClassWithOperator
     {
         public ClassWithOperator() { }
-        public static PublicApiGeneratorTests.Examples.ClassWithOperator +(PublicApiGeneratorTests.Examples.ClassWithOperator first, PublicApiGeneratorTests.Examples.ClassWithOperator second) { }
+        public static PublicApiGeneratorTests.Examples.ClassWithOperator operator +(PublicApiGeneratorTests.Examples.ClassWithOperator first, PublicApiGeneratorTests.Examples.ClassWithOperator second) { }
     }
 }");
         }


### PR DESCRIPTION
Follow-up to #49. Fixes #192.