### PR TITLE
When determining flag combination, match only flags having all of their bits set

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -536,7 +536,7 @@ namespace PublicApiGenerator
                     var flags = from f in type.Fields
                                 where f.Constant != null
                                 let v = Convert.ToInt64(f.Constant)
-                                where v == 0 || (originalValue & v) != 0
+                                where v == 0 || (originalValue & v) == v
                                 select type.FullName + "." + f.Name;
                     return new CodeSnippetExpression(flags.Aggregate((current, next) => current + " | " + next));
                 }

--- a/src/PublicApiGeneratorTests/Class_attributes.cs
+++ b/src/PublicApiGeneratorTests/Class_attributes.cs
@@ -308,6 +308,20 @@ namespace PublicApiGeneratorTests
     }
 }");
         }
+
+        [Fact]
+        public void Should_reproduce_AttributeTargets_value_correctly_on_AttributeUsage_attribute()
+        {
+            AssertPublicApi<ClassWithAttributeUsageAttribute>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    [System.AttributeUsage(System.AttributeTargets.Struct | System.AttributeTargets.Field)]
+    public class ClassWithAttributeUsageAttribute : System.Attribute
+    {
+        public ClassWithAttributeUsageAttribute() { }
+    }
+}");
+        }
     }
 
     // ReSharper disable UnusedMember.Global
@@ -420,6 +434,11 @@ namespace PublicApiGeneratorTests
 
         [Serializable]
         public class ClassWithSerializableAttribute
+        {
+        }
+
+        [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Field)]
+        public class ClassWithAttributeUsageAttribute : Attribute
         {
         }
     }


### PR DESCRIPTION
Resolves #214.

There's one tricky bit that doesn't get resolved here. Say we have these definitions:

```csharp
[Flags]
public enum Letters
{
    A = 1,
    B = 2,
    C = 4,
    AB = A | B,
    All = A | B | C,
}

public class LettersAttribute : Attribute
{
    public LettersAttribute(Letters letters) { }
}

[Letters(Letters.All)]
public class Test { }
```

Should the emitted API for `Test` mention only `[Letters(Letters.All)]`, or `[Letters(Letters.A | Letters.B | Letters.AB | Letters.All)]`? Perhaps the latter, as `All` encompasses all other flags and results in terser output. Finding the minimal set of flags might be quite tricky (or at least computationally more expensive), so I'm leaving that to a future PR for now.