### PR TITLE
Pull up type condition (which type will be included in result)

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -45,7 +45,9 @@ namespace PublicApiGenerator
                 {
                     return CreatePublicApiForAssembly(
                         asm,
-                        typeDefinition => options.IncludeTypes == null || options.IncludeTypes.Any(type => type.FullName == typeDefinition.FullName && type.Assembly.FullName == typeDefinition.Module.Assembly.FullName),
+                        typeDefinition =>!typeDefinition.IsNested &&
+                                         ShouldIncludeType(typeDefinition) &&
+                                         (options.IncludeTypes == null || options.IncludeTypes.Any(type => type.FullName == typeDefinition.FullName && type.Assembly.FullName == typeDefinition.Module.Assembly.FullName)),
                         options.IncludeAssemblyAttributes,
                         options.WhitelistedNamespacePrefixes,
                         attributeFilter);
@@ -111,7 +113,7 @@ namespace PublicApiGenerator
                 }
 
                 var publicTypes = assembly.Modules.SelectMany(m => m.GetTypes())
-                    .Where(t => !t.IsNested && ShouldIncludeType(t) && shouldIncludeType(t))
+                    .Where(shouldIncludeType)
                     .OrderBy(t => t.FullName, StringComparer.Ordinal);
                 foreach (var publicType in publicTypes)
                 {

--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -45,9 +45,9 @@ namespace PublicApiGenerator
                 {
                     return CreatePublicApiForAssembly(
                         asm,
-                        typeDefinition =>!typeDefinition.IsNested &&
-                                         ShouldIncludeType(typeDefinition) &&
-                                         (options.IncludeTypes == null || options.IncludeTypes.Any(type => type.FullName == typeDefinition.FullName && type.Assembly.FullName == typeDefinition.Module.Assembly.FullName)),
+                        typeDefinition => !typeDefinition.IsNested &&
+                                          ShouldIncludeType(typeDefinition) &&
+                                          (options.IncludeTypes == null || options.IncludeTypes.Any(type => type.FullName == typeDefinition.FullName && type.Assembly.FullName == typeDefinition.Module.Assembly.FullName)),
                         options.IncludeAssemblyAttributes,
                         options.WhitelistedNamespacePrefixes,
                         attributeFilter);


### PR DESCRIPTION
This change help me to workaround for #213 (using reflection, using my custom filtration, on my own risk, but I can be able to do it).
Also it doesn't expose ability to generate api text for internal member.

Also this change will get code bit more cleaner (single place for filter types) (I hope).

This change join two predicates which are used to determine which types will be included in result into single one.
Originally part of the predicate was in `GeneratePublicApi` method, another part - in `CreatePublicApiForAssembly` (internal method). 
Now method `CreatePublicApiForAssembly` will receive full predicate from method `GeneratePublicApi`. 
