### PR TITLE
Fix generic arguments for array types

### DIFF
--- a/src/PublicApiGenerator/CodeTypeReferenceBuilder.cs
+++ b/src/PublicApiGenerator/CodeTypeReferenceBuilder.cs
@@ -34,7 +34,12 @@ namespace PublicApiGenerator
         {
             // ReSharper disable once RedundantEnumerableCastCall
             var genericArgs = type is IGenericInstance instance ? instance.GenericArguments : type.HasGenericParameters ? type.GenericParameters.Cast<TypeReference>() : null;
-            if (genericArgs == null) return null;
+            if (genericArgs == null)
+            {
+                return type is ArrayType arr
+                    ? CreateGenericArguments(arr.ElementType, nullabilityMap)
+                    : null;
+            }
 
             var genericArguments = new List<CodeTypeReference>();
             foreach (var argument in genericArgs)

--- a/src/PublicApiGeneratorTests/Expressions.cs
+++ b/src/PublicApiGeneratorTests/Expressions.cs
@@ -1,0 +1,37 @@
+using PublicApiGeneratorTests.Examples;
+using System;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    public class Expressions : ApiGeneratorTestsBase
+    {
+        [Fact]
+        public void Should_write_expression()
+        {
+            AssertPublicApi(typeof(ClassWithExpressions<>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithExpressions<TSourceType>
+    {
+        public ClassWithExpressions(params System.Linq.Expressions.Expression<System.Func<int, object>>[] expr1) { }
+        public ClassWithExpressions(System.Linq.Expressions.Expression<System.Func<int, object>> expr2) { }
+        public ClassWithExpressions(params System.Linq.Expressions.Expression<System.Func<TSourceType, object>>[] expr3) { }
+        public ClassWithExpressions(System.Linq.Expressions.Expression<System.Func<TSourceType, object>> expr4) { }
+    }
+}");
+        }
+    }
+
+    namespace Examples
+    {
+        public class ClassWithExpressions<TSourceType>
+        {
+            public ClassWithExpressions(params Expression<Func<int, object>>[] expr1) { }
+            public ClassWithExpressions(Expression<Func<int, object>> expr2) { }
+            public ClassWithExpressions(params Expression<Func<TSourceType, object>>[] expr3) { }
+            public ClassWithExpressions(Expression<Func<TSourceType, object>> expr4) { }
+        }
+    }
+}

--- a/src/PublicApiGeneratorTests/Expressions.cs
+++ b/src/PublicApiGeneratorTests/Expressions.cs
@@ -16,9 +16,9 @@ namespace PublicApiGeneratorTests
     public class ClassWithExpressions<TSourceType>
     {
         public ClassWithExpressions(params System.Linq.Expressions.Expression<System.Func<int, object>>[] expr1) { }
-        public ClassWithExpressions(System.Linq.Expressions.Expression<System.Func<int, object>> expr2) { }
-        public ClassWithExpressions(params System.Linq.Expressions.Expression<System.Func<TSourceType, object>>[] expr3) { }
-        public ClassWithExpressions(System.Linq.Expressions.Expression<System.Func<TSourceType, object>> expr4) { }
+        public ClassWithExpressions(params System.Linq.Expressions.Expression<System.Func<TSourceType, object?>>[] expr2) { }
+        public ClassWithExpressions(System.Linq.Expressions.Expression<System.Func<TSourceType, object>?> expr3) { }
+        public ClassWithExpressions(System.Linq.Expressions.Expression<System.Func<int, object>>? expr4) { }
     }
 }");
         }
@@ -29,9 +29,9 @@ namespace PublicApiGeneratorTests
         public class ClassWithExpressions<TSourceType>
         {
             public ClassWithExpressions(params Expression<Func<int, object>>[] expr1) { }
-            public ClassWithExpressions(Expression<Func<int, object>> expr2) { }
-            public ClassWithExpressions(params Expression<Func<TSourceType, object>>[] expr3) { }
-            public ClassWithExpressions(Expression<Func<TSourceType, object>> expr4) { }
+            public ClassWithExpressions(params Expression<Func<TSourceType, object?>>[] expr2) { }
+            public ClassWithExpressions(Expression<Func<TSourceType, object>?> expr3) { }
+            public ClassWithExpressions(Expression<Func<int, object>>? expr4) { }
         }
     }
 }


### PR DESCRIPTION
Before this fix such ctor
`public ClassWithExpressions(params Expression<Func<int, object>>[] expr1) { }`
yields
` public ClassWithExpressions(params System.Linq.Expressions.Expression<>[]? expr1) { }`

After fix generator yields
`public ClassWithExpressions(params System.Linq.Expressions.Expression<System.Func<int, object>>[] expr1)`