### PR TITLE
Add support for C# 9 init-only setters

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -761,6 +761,11 @@ namespace PublicApiGenerator
             // TODO: CodeDOM has no support for different access modifiers for getters and setters
             // TODO: CodeDOM has no support for attributes on setters or getters - promote to property?
 
+            if (hasSet && member.SetMethod?.ReturnType is RequiredModifierType reqmod && reqmod.ModifierType.FullName == "System.Runtime.CompilerServices.IsExternalInit")
+            {
+                property.Name = string.Format(CodeNormalizer.PropertyInitOnlySetterTemplate, property.Name);
+            }
+
             typeDeclaration.Members.Add(property);
         }
 

--- a/src/PublicApiGenerator/CodeNormalizer.cs
+++ b/src/PublicApiGenerator/CodeNormalizer.cs
@@ -24,6 +24,7 @@ namespace PublicApiGenerator
         internal const string EventRemovePublicMarker = "removepublic";
         internal const string MethodModifierMarkerTemplate = "_{0}_3C0D97CD952D40AA8B6E1ECB98FFC79F_";
         internal const string PropertyModifierMarkerTemplate = "_{0}_5DB9F56043FF464997155541DA321AD4_";
+        internal const string PropertyInitOnlySetterTemplate = "_{0}_156783F107B3427090B5486DC33EE6A9_";
 
         public static string NormalizeMethodName(string methodName)
         {
@@ -61,6 +62,7 @@ namespace PublicApiGenerator
 
             gennedClass = Regex.Replace(gennedClass, @"(public|protected) (.*) _(.*)_292C96C3C42E4C07BEED73F5DAA0A6DF_(.*)", EventModifierMatcher);
             gennedClass = Regex.Replace(gennedClass, @"(public|protected)( abstract | static | new static | virtual | override | new | unsafe | )(.*) _(.*)_5DB9F56043FF464997155541DA321AD4_(.*)", PropertyModifierMatcher);
+            gennedClass = Regex.Replace(gennedClass, @"_(.*)_156783F107B3427090B5486DC33EE6A9_(.*)", PropertyInitOnlySetterMatcher);
             gennedClass = Regex.Replace(gennedClass, @"(public|protected)( abstract | static | new static | virtual | override | new | unsafe | )(.*) _(.*)_3C0D97CD952D40AA8B6E1ECB98FFC79F_(.*)", MethodModifierMatcher);
             gennedClass = gennedClass.Replace("class " + StaticMarker, "static class ");
             gennedClass = gennedClass.Replace("struct " + ReadonlyMarker, "readonly struct ");
@@ -99,6 +101,13 @@ namespace PublicApiGenerator
 
             var s = match.ToString().Replace(string.Format(PropertyModifierMarkerTemplate, modifier), string.Empty);
             return string.IsNullOrWhiteSpace(oldModifier) ? s.Insert(s.IndexOf(oldModifier, StringComparison.Ordinal), modifier.Substring(0, modifier.Length - 1)) : s.Replace(oldModifier, modifier);
+        }
+
+        static string PropertyInitOnlySetterMatcher(Match match)
+        {
+            var name = match.Groups[1].Value;
+            var tail = match.Groups[2].Value;
+            return name + tail.Replace("set;", "init;");
         }
 
         static string MethodModifierMatcher(Match match)

--- a/src/PublicApiGeneratorTests/Property_methods.cs
+++ b/src/PublicApiGeneratorTests/Property_methods.cs
@@ -1,4 +1,4 @@
-﻿using PublicApiGeneratorTests.Examples;
+using PublicApiGeneratorTests.Examples;
 using Xunit;
 
 namespace PublicApiGeneratorTests
@@ -43,6 +43,34 @@ namespace PublicApiGeneratorTests
     {
         public PropertyWriteOnly() { }
         public string Value { set; }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_getter_and_init_only_setter()
+        {
+            AssertPublicApi<PropertyReadInit>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class PropertyReadInit
+    {
+        public PropertyReadInit() { }
+        public string Value { get; init; }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_init_only_setter_only()
+        {
+            AssertPublicApi<PropertyInitOnly>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class PropertyInitOnly
+    {
+        public PropertyInitOnly() { }
+        public string Value { init; }
     }
 }");
         }
@@ -123,6 +151,16 @@ namespace PublicApiGeneratorTests
         public class PropertyWriteOnly
         {
             public string Value { set { } }
+        }
+
+        public class PropertyReadInit
+        {
+            public string Value { get; init; }
+        }
+
+        public class PropertyInitOnly
+        {
+            public string Value { init { } }
         }
 
         public class PropertyIndexer

--- a/src/PublicApiGeneratorTests/Record.cs
+++ b/src/PublicApiGeneratorTests/Record.cs
@@ -14,8 +14,8 @@ namespace PublicApiGeneratorTests
     public class User : System.IEquatable<PublicApiGeneratorTests.Examples.User>
     {
         public User(string login, string password) { }
-        public string login { get; set; }
-        public string password { get; set; }
+        public string login { get; init; }
+        public string password { get; init; }
     }
 }");
         }


### PR DESCRIPTION
Closes #250.

Not sure if this is the best way to get this done (probably not!), but for now it appears to work.