### PR TITLE
Add CI/CD workflows

### DIFF
--- a/.github/workflows/cd-preview.yml
+++ b/.github/workflows/cd-preview.yml
@@ -1,0 +1,51 @@
+name: Publish preview
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - src/**
+      - .github/workflows/**
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 50
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            3.1.x
+            6.0.x
+            7.0.x
+      - name: Install dependencies
+        working-directory: src
+        run: dotnet restore
+      - name: Build solution [Release]
+        working-directory: src
+        run: dotnet build --no-restore -c Release
+      - name: Publish Tool [Release]
+        working-directory: src
+        run: |
+          dotnet publish PublicApiGenerator.Tool/PublicApiGenerator.Tool.csproj --no-restore --no-build -c Release -f netcoreapp3.1 &&
+          dotnet publish PublicApiGenerator.Tool/PublicApiGenerator.Tool.csproj --no-restore --no-build -c Release -f net6
+      - name: Pack solution [Release]
+        working-directory: src
+        run: dotnet pack --no-restore --no-build -c Release -o out
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Nuget packages
+          path: |
+            src/out/*
+      - name: Publish Nuget packages to GitHub registry
+        working-directory: src
+        run: dotnet nuget push "out/*" -k ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -1,0 +1,68 @@
+name: Publish release
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 50
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            3.1.x
+            6.0.x
+            7.0.x
+      - name: Install dependencies
+        working-directory: src
+        run: dotnet restore
+      - name: Build solution [Release]
+        working-directory: src
+        run: dotnet build --no-restore -c Release
+      - name: Publish Tool [Release]
+        working-directory: src
+        run: |
+          dotnet publish PublicApiGenerator.Tool/PublicApiGenerator.Tool.csproj --no-restore --no-build -c Release -f netcoreapp3.1 &&
+          dotnet publish PublicApiGenerator.Tool/PublicApiGenerator.Tool.csproj --no-restore --no-build -c Release -f net6
+      - name: Pack solution [Release]
+        working-directory: src
+        run: dotnet pack --no-restore --no-build -c Release -o out
+      - name: Upload Nuget packages as workflow artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Nuget packages
+          path: |
+            src/out/*
+      - name: Publish Nuget packages to Nuget registry
+        working-directory: src
+        run: dotnet nuget push "out/*" -k ${{secrets.NUGET_AUTH_TOKEN}}
+      - name: Upload Nuget packages as release artifacts
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            console.log('environment', process.versions);
+            const fs = require('fs').promises;
+            const { repo: { owner, repo }, sha } = context;
+
+            for (let file of await fs.readdir('src/out')) {
+              console.log('uploading', file);
+
+              await github.rest.repos.uploadReleaseAsset({
+                owner,
+                repo,
+                release_id: ${{ github.event.release.id }},
+                name: file,
+                data: await fs.readFile(`src/out/${file}`)
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,27 @@
+name: Run tests
+
 on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - src/**
+      - .github/workflows/**
+  # Upload code coverage results when PRs are merged
   push:
     branches:
-    - master
-    - release-*
-    tags:
-    - '**'
-  pull_request:
+      - master
+    paths:
+      - src/**
+      - .github/workflows/**
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
-  build:
+  test:
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     name: ${{ matrix.os }}
@@ -29,25 +40,42 @@ jobs:
         working-directory: src
         run: dotnet restore
       - name: Build solution [Release]
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
         working-directory: src
         run: dotnet build --no-restore -c Release
       - name: Build solution [Debug]
         working-directory: src
         run: dotnet build --no-restore -c Debug
-      - name: Test solution [Debug]
+      - name: Test solution [Debug] with code coverage
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        working-directory: src
+        run: >
+          dotnet test
+          --no-restore
+          --no-build
+          --collect "XPlat Code Coverage"
+          --results-directory .coverage
+          --
+          DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+      - name: Test solution [Debug] without code coverage
+        if: ${{ startsWith(matrix.os, 'windows') }}
         working-directory: src
         run: dotnet test --no-restore --no-build
-      - name: Publish Tool [Release]
-        working-directory: src
-        run: |
-          dotnet publish PublicApiGenerator.Tool/PublicApiGenerator.Tool.csproj --no-restore --no-build -c Release -f netcoreapp3.1 &&
-          dotnet publish PublicApiGenerator.Tool/PublicApiGenerator.Tool.csproj --no-restore --no-build -c Release -f net6
-      - name: Pack solution [Release]
-        working-directory: src
-        run: dotnet pack --no-restore --no-build -c Release -o out
-      - name: Upload Nuget packages as workflow artifacts
-        uses: actions/upload-artifact@v3
+      - name: Upload coverage to codecov
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        uses: codecov/codecov-action@v3
         with:
-          name: Nuget packages
-          path: |
-            src/out/*
+          files: 'src/.coverage/**/coverage.opencover.xml'
+
+  buildcheck:
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Pass build check
+        if: ${{ needs.test.result == 'success' }}
+        run: exit 0
+      - name: Fail build check
+        if: ${{ needs.test.result != 'success' }}
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -11,33 +11,33 @@ PublicApiGenerator supports C# 8 [Nullable Reference Types](https://docs.microso
 
 Public API of an assembly
 
-``` csharp
+```csharp
 var publicApi = typeof(Library).Assembly.GeneratePublicApi();
 ```
 
 Public API of multiple types
 
-``` csharp
+```csharp
 var myTypes = new[] { typeof(MyType), typeof(YetAnotherType) };
 var publicApi = typeof(myTypes).GeneratePublicApi();
 ```
 
 Public API of a type
 
-``` csharp
+```csharp
 var publicApi = typeof(MyType).GeneratePublicApi();
 ```
 
 More control over the API output
 
-``` csharp
+```csharp
 var options = new ApiGeneratorOptions { ... };
 var publicApi = typeof(Library).Assembly.GeneratePublicApi(options);
 ```
 
 ### Manual
 
-``` csharp
+```csharp
 [Fact]
 public void my_assembly_has_no_public_api_changes()
 {
@@ -62,7 +62,7 @@ public void my_assembly_has_no_public_api_changes()
 
 > Install-package Shouldly
 
-``` csharp
+```csharp
 [Fact]
 public void my_assembly_has_no_public_api_changes()
 {
@@ -79,7 +79,7 @@ public void my_assembly_has_no_public_api_changes()
 
 > Install-package ApprovalTests
 
-``` csharp
+```csharp
 [Fact]
 public void my_assembly_has_no_public_api_changes()
 {
@@ -111,7 +111,7 @@ private class AssemblyPathNamer : UnitTestFrameworkNamer
 
 > Install-package Verify.Xunit
 
-``` csharp
+```csharp
 [UsesVerify]
 public class Tests
 {
@@ -129,7 +129,7 @@ Or
 
 > Install-package Verify.NUnit
 
-``` csharp
+```csharp
 [Test]
 public Task my_assembly_has_no_public_api_changes()
 {
@@ -143,7 +143,7 @@ Or
 
 > Install-package Verify.MSTest
 
-``` csharp
+```csharp
 
 [TestClass]
 public class VerifyObjectSamples :

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,13 +6,13 @@
     <PackageTags>semanticversioning versioning api</PackageTags>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <MinVerMinimumMajorMinor>10.0</MinVerMinimumMajorMinor>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
     <DebugType>embedded</DebugType>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <MinVerDefaultPreReleaseIdentifiers>preview</MinVerDefaultPreReleaseIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/src/PublicApiGenerator.sln
+++ b/src/PublicApiGenerator.sln
@@ -12,8 +12,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.editorconfig = ..\.editorconfig
 		..\.gitattributes = ..\.gitattributes
 		..\.gitignore = ..\.gitignore
-		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
-		..\.github\dependabot.yml = ..\.github\dependabot.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		..\LICENSE = ..\LICENSE
@@ -22,6 +20,18 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PublicApiGenerator.Tool", "PublicApiGenerator.Tool\PublicApiGenerator.Tool.csproj", "{EDD62C2E-4CCC-4069-8450-85514810008E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{FDD9792D-8E91-41C6-B42A-9E69831F61DF}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\dependabot.yml = ..\.github\dependabot.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{1ED058E7-B50B-4C32-9B20-3C24F87724B5}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\workflows\cd-release.yml = ..\.github\workflows\cd-release.yml
+		..\.github\workflows\cd-preview.yml = ..\.github\workflows\cd-preview.yml
+		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,6 +54,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1ED058E7-B50B-4C32-9B20-3C24F87724B5} = {FDD9792D-8E91-41C6-B42A-9E69831F61DF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {897E3421-9C9A-4E5B-B816-164C2D897BCB}

--- a/src/PublicApiGeneratorTests/PublicApiGeneratorTests.csproj
+++ b/src/PublicApiGeneratorTests/PublicApiGeneratorTests.csproj
@@ -29,6 +29,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #258 

This PR adds 3 workflows:
- `ci` to run tests for pull requests without publish any artifacts
- `cd-preview` to pack/publish nuget packages to GitHub registry on each push into `master`
- `cd-release` to pack/publish nuget packages to nuget.org when publishing release from GitHub