### PR TITLE
Introduce two new options

### DIFF
--- a/src/PublicApiGenerator/ApiGeneratorOptions.cs
+++ b/src/PublicApiGenerator/ApiGeneratorOptions.cs
@@ -1,33 +1,59 @@
 namespace PublicApiGenerator;
 
 /// <summary>
-/// Options to influence the ApiGenerator
+/// Options to influence the ApiGenerator output.
 /// </summary>
 public class ApiGeneratorOptions
 {
     /// <summary>
-    /// Allows to control which types of the generated assembly should be included. If this option is specified all other types found in the assembly that are not present here will be exclude.
+    /// Allows to control which types of the generated assembly should be included.
+    /// If this option is specified all other types found in the assembly that are not present here will be excluded.
     /// </summary>
     public Type[]? IncludeTypes { get; set; }
 
     /// <summary>
     /// Instructs the generator to include assembly level attributes.
     /// </summary>
-    /// <remarks>Defaults to true</remarks>
+    /// <remarks>Defaults to <see langword="true"/>.</remarks>
     public bool IncludeAssemblyAttributes { get; set; } = true;
 
     /// <summary>
-    /// Allows to whitelist certain namespace prefixes. For example by default types found in Microsoft or System namespaces are not treated as part of the public API.
+    /// Allows to whitelist certain namespace prefixes.
+    /// For example by default types found in Microsoft or System namespaces are not treated as part of the public API.
+    /// This option has priority over <see cref="BlacklistedNamespacePrefixes"/>.
     /// </summary>
     /// <example>
     /// <code>
     /// var options = new DefaultApiGeneratorOptions
     /// {
-    ///    WhitelistedNamespacePrefixes = new[] {"Microsoft.Whitelisted" }
+    ///    WhitelistedNamespacePrefixes = new[] { "Microsoft.Whitelisted" }
     /// };
     /// </code>
     /// </example>
-    public string[] WhitelistedNamespacePrefixes { get; set; } = DefaultWhitelistedNamespacePrefixes;
+    public string[] WhitelistedNamespacePrefixes { get; set; } = _defaultWhitelistedNamespacePrefixes;
+
+    /// <summary>
+    /// Allows to blacklist certain namespace prefixes.
+    /// By default types found in Microsoft or System namespaces are not treated as part of the public API.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var options = new DefaultApiGeneratorOptions
+    /// {
+    ///    BlacklistedNamespacePrefixes = new[] { "System", "Microsoft", "ThirdParty" }
+    /// };
+    /// </code>
+    /// </example>
+    public string[] BlacklistedNamespacePrefixes { get; set; } = _defaultBlacklistedNamespacePrefixes;
+
+    /// <summary>
+    /// Allows to control whether to include extension methods into generated API even when
+    /// containing class falls into <see cref="BlacklistedNamespacePrefixes"/> option. This
+    /// option may be useful, for example, for those who writes extensions for IServiceCollection
+    /// keeping them into Microsoft.Extensions.DependencyInjection namespace for better discoverability.
+    /// </summary>
+    /// <remarks>Defaults to <see langword="true"/>, i.e. extension methods are excluded from output.</remarks>
+    public bool UseBlacklistedNamespacePrefixesForExtensionMethods { get; set; } = true;
 
     /// <summary>
     /// Allows to exclude attributes by specifying the fullname of the attribute to exclude.
@@ -42,5 +68,7 @@ public class ApiGeneratorOptions
     /// </example>
     public string[]? ExcludeAttributes { get; set; }
 
-    static readonly string[] DefaultWhitelistedNamespacePrefixes = Array.Empty<string>();
+    private static readonly string[] _defaultWhitelistedNamespacePrefixes = Array.Empty<string>();
+
+    private static readonly string[] _defaultBlacklistedNamespacePrefixes = new[] { "System", "Microsoft" };
 }

--- a/src/PublicApiGeneratorTests/Method_extensions.cs
+++ b/src/PublicApiGeneratorTests/Method_extensions.cs
@@ -19,6 +19,19 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_output_extension_methods_when_allowed()
+        {
+            AssertPublicApi(typeof(StringExtensionsInSystemNamespace),
+@"namespace System
+{
+    public static class StringExtensionsInSystemNamespace
+    {
+        public static bool CheckLength(this string value, int length) { }
+    }
+}", new PublicApiGenerator.ApiGeneratorOptions { UseBlacklistedNamespacePrefixesForExtensionMethods = false, IncludeAssemblyAttributes = false });
+        }
+
+        [Fact]
         public void Should_output_generic_extension_methods()
         {
             AssertPublicApi(typeof(GenericExtensions),
@@ -87,4 +100,20 @@ namespace PublicApiGeneratorTests
     }
     // ReSharper restore ClassNeverInstantiated.Global
     // ReSharper restore UnusedMember.Global
+}
+
+namespace System
+{
+    public static class StringExtensionsInSystemNamespace
+    {
+        public static bool CheckLength(this string value, int length)
+        {
+            return value.Length == length;
+        }
+
+        public static bool CheckLengthNotAsExtension(string value, int length)
+        {
+            return value.Length == length;
+        }
+    }
 }

--- a/src/PublicApiGeneratorTests/Namespaces_whitelisting.cs
+++ b/src/PublicApiGeneratorTests/Namespaces_whitelisting.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Whitelisted;
+using Microsoft.Whitelisted;
 using System.Whitelisted;
 
 namespace PublicApiGeneratorTests
@@ -10,7 +10,7 @@ namespace PublicApiGeneratorTests
         {
             var options = new DefaultApiGeneratorOptions
             {
-                WhitelistedNamespacePrefixes = new[] {"Microsoft.Whitelisted"}
+                WhitelistedNamespacePrefixes = new[] { "Microsoft.Whitelisted" }
             };
 
             AssertPublicApi(new[] { typeof(Simple1), typeof(Simple2) },
@@ -32,12 +32,7 @@ namespace PublicApiGeneratorTests
         [Fact]
         public void Should_filter_microsoft_namespace()
         {
-            AssertPublicApi(new[] { typeof(Simple1), typeof(Simple2) },
-                @"namespace Microsoft.Whitelisted
-{
-    public class Simple1 { }
-    public class Simple2 { }
-}");
+            AssertPublicApi(new[] { typeof(Simple1), typeof(Simple2) }, "");
         }
 
         [Fact]
@@ -48,7 +43,7 @@ namespace PublicApiGeneratorTests
                 WhitelistedNamespacePrefixes = new[] { "System.Whitelisted" }
             };
 
-            AssertPublicApi(new[] { typeof(System1), typeof(System2)},
+            AssertPublicApi(new[] { typeof(System1), typeof(System2) },
                 @"namespace System.Whitelisted
 {
     public class System1
@@ -67,12 +62,7 @@ namespace PublicApiGeneratorTests
         [Fact]
         public void Should_filter_system_namespace()
         {
-            AssertPublicApi(new[] { typeof(System1), typeof(System2) },
-                @"namespace System.Whitelisted
-{
-    public class System1 { }
-    public class System2 { }
-}");
+            AssertPublicApi(new[] { typeof(System1), typeof(System2) }, "");
         }
     }
 }

--- a/src/PublicApiGeneratorTests/PublicApiGenerator.approved.txt
+++ b/src/PublicApiGeneratorTests/PublicApiGenerator.approved.txt
@@ -12,9 +12,11 @@ namespace PublicApiGenerator
     public class ApiGeneratorOptions
     {
         public ApiGeneratorOptions() { }
+        public string[] BlacklistedNamespacePrefixes { get; set; }
         public string[]? ExcludeAttributes { get; set; }
         public bool IncludeAssemblyAttributes { get; set; }
         public System.Type[]? IncludeTypes { get; set; }
+        public bool UseBlacklistedNamespacePrefixesForExtensionMethods { get; set; }
         public string[] WhitelistedNamespacePrefixes { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #184 in two aspects:
1. It never prints "empty" classes like that
```c#
namespace System.IdentityModel.Tokens.Jwt
{
    public static class JwtSecurityTokenExtensions { }
}
```
Those classes are completely excluded from output, i.e. whitelisting works now for types as well.

2. If one wants to output extension methods even from "blacklisted" namespaces then he may set `options.UseBlacklistedNamespacePrefixesForExtensionMethods = false` 

Also I moved hardcoded `System` and `Microsoft` prefixes into public `BlacklistedNamespacePrefixes` option.

@danielmarbach @stakx please review.
