### PR TITLE
Update the Verify.Xunit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ private class AssemblyPathNamer : UnitTestFrameworkNamer
 > Install-package Verify.Xunit
 
 ```csharp
-[UsesVerify]
 public class Tests
 {
     [Fact]


### PR DESCRIPTION
The `UsesVerify` attribute is [no longer required](https://github.com/VerifyTests/Verify/pull/1131) and it can be removed.