### PR TITLE
Add failing test for long string attribute arguments

### DIFF
--- a/src/PublicApiGeneratorTests/Class_attributes.cs
+++ b/src/PublicApiGeneratorTests/Class_attributes.cs
@@ -275,6 +275,20 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_handle_attribute_with_long_string_initialiser()
+        {
+            AssertPublicApi<ClassWithAttributeWithLongStringInitialiser>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    [PublicApiGeneratorTests.Examples.AttributeWithStringInitialiser(""This is a very long string that will be surrounded by parenthesis due to how it's handled by Microsoft.CodeDom"")]
+    public class ClassWithAttributeWithStringInitialiser
+    {
+        public ClassWithAttributeWithStringInitialiser() { }
+    }
+}");
+        }
+
+        [Fact]
         public void Should_not_output_internal_attributes()
         {
             AssertPublicApi<ClassWithInternalAttribute>(
@@ -435,6 +449,12 @@ namespace PublicApiGeneratorTests
         [AttributeWithMultipleUsagesSupport(IntValue = 2, StringValue = "AAA")]
         public class ClassWithAttributeWithMultipleUsagesSupport
         {
+        }
+
+        [AttributeWithStringInitialiser("This is a very long string that will be surrounded by parenthesis due to how it's handled by Microsoft.CodeDom")]
+        public class ClassWithAttributeWithLongStringInitialiser()
+        {
+
         }
 
         [AttributeWhichIsInternal]

--- a/src/PublicApiGeneratorTests/HelperTypes.cs
+++ b/src/PublicApiGeneratorTests/HelperTypes.cs
@@ -158,6 +158,13 @@ public class AttributeWithMultipleUsagesSupport : Attribute
     public int IntValue;
 }
 
+[AttributeUsage(AttributeTargets.All)]
+public class AttributeWithStringInitialiser : Attribute
+{
+    public AttributeWithStringInitialiser(string value)
+    {
+    }
+}
 public class AttributeWithObjectArrayInitialiser : Attribute
 {
     public AttributeWithObjectArrayInitialiser(params object[] values)


### PR DESCRIPTION
Added a test that shows how long strings as attribute arguments will be surrounded by parenthesis.