### PR TITLE
Support native sized integers

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -333,6 +333,8 @@ public static class ApiGenerator
                 ReturnType = invokeMethod.ReturnType.CreateCodeTypeReference(invokeMethod.MethodReturnType),
             };
 
+            if (invokeMethod.MethodReturnType.IsNativeInteger(invokeMethod.ReturnType.FullName))
+                declaration.ReturnType.MakeNativeInteger();
             // CodeDOM. No support. Return type attributes.
             PopulateCustomAttributes(invokeMethod.MethodReturnType, declaration.CustomAttributes, type => type.MakeReturn(), attributeFilter);
             PopulateGenericParameters(publicType, declaration.TypeParameters, attributeFilter, _ => true);
@@ -599,6 +601,9 @@ public static class ApiGenerator
             CustomAttributes = CreateCustomAttributes(member, attributeFilter),
             ReturnType = returnType,
         };
+
+        if (member.MethodReturnType.IsNativeInteger(member.ReturnType.FullName))
+            method.ReturnType.MakeNativeInteger();
         PopulateCustomAttributes(member.MethodReturnType, method.ReturnTypeCustomAttributes, attributeFilter);
         PopulateGenericParameters(member, method.TypeParameters, attributeFilter, _ => true);
         PopulateMethodParameters(member, method.Parameters, attributeFilter, member.IsExtensionMethod());
@@ -655,6 +660,9 @@ public static class ApiGenerator
                 Direction = direction,
                 CustomAttributes = CreateCustomAttributes(parameter, attributeFilter)
             };
+
+            if (parameter.IsNativeInteger(parameter.ParameterType.FullName))
+                expression.Type.MakeNativeInteger();
             parameters.Add(expression);
         }
     }

--- a/src/PublicApiGenerator/AttributeFilter.RequiredAttributeNames.cs
+++ b/src/PublicApiGenerator/AttributeFilter.RequiredAttributeNames.cs
@@ -24,6 +24,9 @@ internal partial class AttributeFilter
         "System.Runtime.CompilerServices.CallerFilePath",
         "System.Runtime.CompilerServices.CallerLineNumberAttribute",
         "System.Runtime.CompilerServices.CallerMemberName",
-        "System.Runtime.CompilerServices.ReferenceAssemblyAttribute"
+        "System.Runtime.CompilerServices.ReferenceAssemblyAttribute",
+        // Native sized integers
+        // https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types#native-sized-integers
+        "System.Runtime.CompilerServices.NativeIntegerAttribute",
     };
 }

--- a/src/PublicApiGenerator/System.CodeDom/CSharpCodeGenerator.cs
+++ b/src/PublicApiGenerator/System.CodeDom/CSharpCodeGenerator.cs
@@ -2702,6 +2702,11 @@ namespace Microsoft.CSharp
                     continue;
                 }
 
+                if (current.Name.Equals("System.Runtime.CompilerServices.NativeIntegerAttribute") || current.Name.Equals("return: System.Runtime.CompilerServices.NativeIntegerAttribute"))
+                {
+                    continue;
+                }
+
                 GenerateAttributeDeclarationsStart();
                 if (prefix != null)
                 {
@@ -2852,6 +2857,14 @@ namespace Microsoft.CSharp
                 }
 
                 string lowerCaseString = s.ToLowerInvariant().Trim();
+
+                if (typeRef.UserData.Contains("System.Runtime.CompilerServices.NativeIntegerAttribute"))
+                {
+                    if (lowerCaseString == "system.intptr")
+                        return "nint";
+                    else if (lowerCaseString == "system.uintptr")
+                        return "nuint";
+                }
 
                 switch (lowerCaseString)
                 {

--- a/src/PublicApiGeneratorTests/Delegate_types.cs
+++ b/src/PublicApiGeneratorTests/Delegate_types.cs
@@ -5,6 +5,17 @@ namespace PublicApiGeneratorTests
     public class Delegate_types : ApiGeneratorTestsBase
     {
         [Fact]
+        public void Should_output_native_delegate()
+        {
+            AssertPublicApi<NativeDelegate>("""
+namespace PublicApiGeneratorTests.Examples
+{
+    public delegate nint NativeDelegate(nuint v);
+}
+""");
+        }
+
+        [Fact]
         public void Should_output_dynamic_delegate()
         {
             AssertPublicApi<DynamicDelegate>("""
@@ -73,6 +84,7 @@ namespace PublicApiGeneratorTests.Examples
 
     namespace Examples
     {
+        public delegate nint NativeDelegate(nuint v);
         public delegate dynamic DynamicDelegate(dynamic v);
         public delegate void VoidDelegate();
         public delegate int DelegateWithPrimitiveParameters(int v1, string v2);

--- a/src/PublicApiGeneratorTests/NativeIntegers.cs
+++ b/src/PublicApiGeneratorTests/NativeIntegers.cs
@@ -1,0 +1,55 @@
+using PublicApiGeneratorTests.Examples;
+
+namespace PublicApiGeneratorTests
+{
+    public class NativeIntegers : ApiGeneratorTestsBase
+    {
+        [Fact]
+        public void Should_output_native_integers()
+        {
+#if NET7_0_OR_GREATER
+            AssertPublicApi<ClassWithNativeIntegers>("""
+namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithNativeIntegers
+    {
+        public nint Add1(nint a, nint b) { }
+        public nuint Add2(nuint a, nuint b) { }
+        public nint Add3(nint a, nint b) { }
+        public nuint Add4(nuint a, nuint b) { }
+    }
+}
+""");
+#else
+            AssertPublicApi<ClassWithNativeIntegers>("""
+namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithNativeIntegers
+    {
+        public nint Add1(nint a, nint b) { }
+        public nuint Add2(nuint a, nuint b) { }
+        public System.IntPtr Add3(System.IntPtr a, System.IntPtr b) { }
+        public System.UIntPtr Add4(System.UIntPtr a, System.UIntPtr b) { }
+    }
+}
+""");
+#endif
+        }
+    }
+
+    namespace Examples
+    {
+        public class ClassWithNativeIntegers
+        {
+            private ClassWithNativeIntegers() { }
+
+            public nint Add1(nint a, nint b) => a + b;
+
+            public nuint Add2(nuint a, nuint b) => a + b;
+
+            public IntPtr Add3(IntPtr a, IntPtr b) => throw null;
+
+            public UIntPtr Add4(UIntPtr a, UIntPtr b) => throw null;
+        }
+    }
+}


### PR DESCRIPTION
@stakx mentioned `nint` and `nuint` in #207

Note that since .NET7 `nint` is a true alias for `System.IntPtr` and `nuint` is a true alias for `System.UIntPtr`.