### PR TITLE
Fix syntax for generating public API in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Public API of multiple types
 
 ```csharp
 var myTypes = new[] { typeof(MyType), typeof(YetAnotherType) };
-var publicApi = typeof(myTypes).GeneratePublicApi();
+var publicApi = myTypes.GeneratePublicApi();
 ```
 
 Public API of a type


### PR DESCRIPTION
This fixes a small error in README when API is generated for multiple types.

The extension method in https://github.com/PublicApiGenerator/PublicApiGenerator/blob/20233d01273f0311b448c399662a63ab28e651a0/src/PublicApiGenerator/ApiGenerator.cs#L60 operates on `Type[]`, the `typeof` operator is wrong here.